### PR TITLE
Allows internet when RaspberryPi is set as AP

### DIFF
--- a/dev/source/docs/making-a-mavlink-wifi-bridge-using-the-raspberry-pi.rst
+++ b/dev/source/docs/making-a-mavlink-wifi-bridge-using-the-raspberry-pi.rst
@@ -214,7 +214,7 @@ change the file so it matches the following:
 
 ::
 
-    auto lo
+    auto lo eth0
 
     iface lo inet loopback
     iface eth0 inet dhcp
@@ -396,7 +396,7 @@ The complete file should now look like this:
 
 ::
 
-    auto lo
+    auto lo eth0
 
     iface lo inet loopback
     iface eth0 inet dhcp


### PR DESCRIPTION
This change in /etc/network/interfaces allowed internet connected using Ethernet cable and also for my PC (Win 10) connected to it.

changed lines:
New: auto lo eth0
Old: auto lo